### PR TITLE
Fix info url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+# It's easy to add more libraries or choose different versions. Any libraries
+# specified here will be installed and made available to your morph.io scraper.
+# Find out more: https://morph.io/documentation/ruby
+
+source "https://rubygems.org"
+
+ruby "2.0.0"
+
+gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
+gem "mechanize"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,50 @@
+GIT
+  remote: https://github.com/openaustralia/scraperwiki-ruby.git
+  revision: fc50176812505e463077d5c673d504a6a234aa78
+  branch: morph_defaults
+  specs:
+    scraperwiki (3.0.1)
+      httpclient
+      sqlite_magic
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    httpclient (2.6.0.1)
+    mechanize (2.7.3)
+      domain_name (~> 0.5, >= 0.5.1)
+      http-cookie (~> 1.0)
+      mime-types (~> 2.0)
+      net-http-digest_auth (~> 1.1, >= 1.1.1)
+      net-http-persistent (~> 2.5, >= 2.5.2)
+      nokogiri (~> 1.4)
+      ntlm-http (~> 0.1, >= 0.1.1)
+      webrobots (>= 0.0.9, < 0.2)
+    mime-types (2.6.1)
+    mini_portile (0.6.2)
+    net-http-digest_auth (1.4)
+    net-http-persistent (2.9.4)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    ntlm-http (0.1.1)
+    sqlite3 (1.3.10)
+    sqlite_magic (0.0.6)
+      sqlite3
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
+    webrobots (0.1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mechanize
+  scraperwiki!
+
+BUNDLED WITH
+   1.10.6

--- a/scraper.rb
+++ b/scraper.rb
@@ -3,10 +3,10 @@ require 'mechanize'
 
 agent = Mechanize.new
 
-url = 'https://eproperty.marrickville.nsw.gov.au/eServices/P1/PublicNotices/AllPublicNotices.aspx?r=%24P1.WEBGUEST&f=%24P1.ESB.PUBNOTAL.ENQ'
+url = 'https://eproperty.marrickville.nsw.gov.au/eServices/P1/PublicNotices/AllPublicNotices.aspx?r=MC.P1.WEBGUEST&f=%24P1.ESB.PUBNOTAL.ENQ'
 page = agent.get(url)
 
-base_info_url = 'https://eproperty.marrickville.nsw.gov.au/eServices/P1/PublicNotices/PublicNoticeDetails.aspx?r=%24P1.WEBGUEST&f=%24P1.ESB.PUBNOT.VIW&ApplicationId='
+base_info_url = 'https://eproperty.marrickville.nsw.gov.au/eServices/P1/PublicNotices/PublicNoticeDetails.aspx?r=MC.P1.WEBGUEST&f=%24P1.ESB.PUBNOT.VIW&ApplicationId='
 comment_url = 'http://www.marrickville.nsw.gov.au/en/development/development-applications/da-on-exhibition/lodge-a-comment-on-a-da/'
 
 (page/'//*[@id="ctl00_Content_cusApplicationResultsGrid_pnlCustomisationGrid"]').search('table').each do |t|


### PR DESCRIPTION
The council has changed their urls. On the DA index they are
redirecting to the correct URL which means the scraper can still
find all the DAs. However, for the individual DA pages they are not
redirecting, so the info URL don't work.

Compare https://eproperty.marrickville.nsw.gov.au/eServices/P1/PublicNotices/PublicNoticeDetails.aspx?r=MC.P1.WEBGUEST&f=%24P1.ESB.PUBNOT.VIW&ApplicationId=DA201500105
with
https://eproperty.marrickville.nsw.gov.au/eServices/P1/PublicNotices/PublicNoticeDetails.aspx?r=%24P1.WEBGUEST&f=%24P1.ESB.PUBNOT.VIW&ApplicationId=DA201500105

The first URL take you to the DA page, the second redirects to
https://eproperty.marrickville.nsw.gov.au/eServices/P1Unauthorised.aspx

This commit fixes both the index url and the info url base.

A user alerted me to this via email.
